### PR TITLE
fix: update base_url in MODELS_URL

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -26,7 +26,7 @@ _data_home = environ.get(
 )
 
 MODELS_URL = {
-    model_type: f"https://huggingface.co/datasets/ggerganov/whisper.cpp/resolve/main/ggml-{model_type}.bin"
+    model_type: f"https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-{model_type}.bin"
     for model_type in (
         "tiny.en",
         "tiny",


### PR DESCRIPTION
Fixes 401 error when downloading models directly from huggingface e.g. via `from_pretrained()`. 

Reference: https://github.com/aarnphm/whispercpp/issues/137 and https://github.com/aarnphm/whispercpp/pull/130